### PR TITLE
Add `\percent`

### DIFF
--- a/siunitx.satyh
+++ b/siunitx.satyh
@@ -99,6 +99,8 @@ direct \mmHg          : [] math-cmd
 direct \nauticalmile  : [] math-cmd
 direct \neper         : [] math-cmd
 
+direct \percent : [] math-cmd
+
 end = struct
 
 
@@ -210,5 +212,7 @@ let-math \knot         = ord `kn`
 let-math \mmHg         = ord `mmHg`
 let-math \nauticalmile = ord `M`
 let-math \neper        = ord `Np`
+
+let-math \percent = ord `%`
 
 end


### PR DESCRIPTION
"%" sign is a valid SI unit.  See [The International System of Units (SI) 9th edition, Section 5.4.7](https://www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf/2d2b50bf-f2b4-9661-f402-5f9d66e4b507#page=37).